### PR TITLE
css gap property를 금지

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,6 @@ module.exports = {
     "no-eol-whitespace": [true, {
       "ignore": ["empty-lines"],
     }],
+    "property-disallowed-list": ["gap"]
   },
 }


### PR DESCRIPTION
* Safari 14.1 부터 지원되는 attribute ([Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/gap))
* 2021년 4월 릴리즈이기 때문에 위험